### PR TITLE
feat(api): implement REST endpoints for products

### DIFF
--- a/spring/.clinerules/memory-bank/activeContext.md
+++ b/spring/.clinerules/memory-bank/activeContext.md
@@ -4,13 +4,14 @@
 With the `ProductRepository` in place, the next priority is to implement the business logic in the `ProductService`.
 
 ## Recent Changes
+- **Completed `task-10`**: Implemented REST Endpoints in 'ProductController'.
 - **Completed `task-8`**: Created the `ProductRepository` interface and added integration tests.
 - **Completed `task-7`**: Created the initial database schema with a Flyway migration script.
 - **Completed `task-6`**: Defined the `Product` JPA Entity.
 - Added Testcontainers to the project for robust integration testing against a real PostgreSQL database.
 
 ## Next Steps
-1.  **Proceed with `task-10`**: Implement REST Endpoints in 'ProductController'.
+1.  **Proceed with `task-11`**: Add Unit, Repository, and Integration Tests.
 
 ## Active Decisions and Considerations
 - The project will strictly follow the Git Flow branching model. All new work will be done on feature branches off of `develop`.

--- a/spring/.clinerules/memory-bank/progress.md
+++ b/spring/.clinerules/memory-bank/progress.md
@@ -9,13 +9,12 @@
 
 ## What's Left to Build
 The rest of the application layers need to be implemented:
-1.  Controller layer.
-2.  Comprehensive testing.
-3.  Final documentation and deployment preparation.
+1.  Comprehensive testing.
+2.  Final documentation and deployment preparation.
 
 ## Current Status
 - **Phase**: Development.
-- **Next Task**: `task-10 - Implement-REST-Endpoints-in-'ProductController'.md`.
+- **Next Task**: `task-11 - Add-Unit,-Repository,-and-Integration-Tests.md`.
 
 ## Known Issues
 - No known issues.

--- a/spring/backlog/tasks/task-10 - Implement-REST-Endpoints-in-'ProductController'.md
+++ b/spring/backlog/tasks/task-10 - Implement-REST-Endpoints-in-'ProductController'.md
@@ -1,9 +1,10 @@
 ---
 id: task-10
 title: Implement REST Endpoints in 'ProductController'
-status: To Do
+status: Done
 assignee: []
 created_date: '2025-07-28'
+updated_date: '2025-07-31'
 labels:
   - api
   - controller
@@ -48,3 +49,17 @@ Implementation Plan:
 4. Implement methods for all MVP endpoints, using DTOs for request and response bodies.
 5. Implement a mapper component to convert between entities and DTOs.
 6. Create a @ControllerAdvice class to handle custom exceptions and return appropriate HTTP errors.
+
+## Implementation Notes
+
+[2025-07-31 18:07:38] - Created  and  DTOs.
+
+[2025-07-31 18:12:08] - Created  and .
+
+[2025-07-31 18:17:00] - Created unit tests for .
+
+[2025-07-31 18:17:56] - Created integration tests for .
+
+[2025-07-31 18:20:25] - Manually validated the endpoints using .
+
+[2025-07-31 18:20:54] - Total time spent: 18 minutes.

--- a/spring/src/main/java/com/thedavestack/productcatalog/controller/ProductController.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/controller/ProductController.java
@@ -1,21 +1,17 @@
 package com.thedavestack.productcatalog.controller;
 
-import com.thedavestack.productcatalog.dto.CreateProductRequest;
-import com.thedavestack.productcatalog.dto.ProductResponse;
-import com.thedavestack.productcatalog.dto.CreateProductRequest;
-import com.thedavestack.productcatalog.dto.ProductResponse;
-import com.thedavestack.productcatalog.mapper.ProductMapper;
-import com.thedavestack.productcatalog.model.Product;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
 import com.thedavestack.productcatalog.dto.CreateProductRequest;
 import com.thedavestack.productcatalog.dto.ProductResponse;
 import com.thedavestack.productcatalog.exception.ProductNotFoundException;
 import com.thedavestack.productcatalog.mapper.ProductMapper;
 import com.thedavestack.productcatalog.model.Product;
 import com.thedavestack.productcatalog.service.ProductService;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/products")
@@ -27,7 +23,8 @@ public class ProductController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ProductResponse createProduct(@RequestBody @Valid CreateProductRequest createProductRequest) {
+    public ProductResponse createProduct(
+            @RequestBody @Valid CreateProductRequest createProductRequest) {
         Product product = productMapper.toEntity(createProductRequest);
         Product createdProduct = productService.createProduct(product);
         return productMapper.toResponse(createdProduct);
@@ -35,7 +32,8 @@ public class ProductController {
 
     @GetMapping("/{id}")
     public ProductResponse getProductById(@PathVariable String id) {
-        Product product = productService.findById(id).orElseThrow(() -> new ProductNotFoundException(id));
+        Product product =
+                productService.findById(id).orElseThrow(() -> new ProductNotFoundException(id));
         return productMapper.toResponse(product);
     }
 }

--- a/spring/src/main/java/com/thedavestack/productcatalog/controller/ProductController.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/controller/ProductController.java
@@ -1,3 +1,17 @@
+/**
+ * ProductController.java
+ *
+ * <p>Design Doc: ./docs/doc-1 - API-Design-Product-Catalog.md
+ *
+ * <p>Purpose: - Handles HTTP requests related to product accounts. - GET /products/:id → fetch
+ * product by ID - POST /products → create a new product
+ *
+ * <p>Logic Overview: 1. Validate request payloads and parameters. 2. Call the corresponding
+ * ProductService method to interact with the database. 3. Handle errors using a centralized error
+ * handler. 4. Send appropriate HTTP status codes and JSON responses.
+ *
+ * <p>Last Updated: 2025-07-31 by Cline (Model: claude-3-opus, Task: task-10)
+ */
 package com.thedavestack.productcatalog.controller;
 
 import org.springframework.http.HttpStatus;

--- a/spring/src/main/java/com/thedavestack/productcatalog/controller/ProductController.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/controller/ProductController.java
@@ -1,0 +1,41 @@
+package com.thedavestack.productcatalog.controller;
+
+import com.thedavestack.productcatalog.dto.CreateProductRequest;
+import com.thedavestack.productcatalog.dto.ProductResponse;
+import com.thedavestack.productcatalog.dto.CreateProductRequest;
+import com.thedavestack.productcatalog.dto.ProductResponse;
+import com.thedavestack.productcatalog.mapper.ProductMapper;
+import com.thedavestack.productcatalog.model.Product;
+import com.thedavestack.productcatalog.dto.CreateProductRequest;
+import com.thedavestack.productcatalog.dto.ProductResponse;
+import com.thedavestack.productcatalog.exception.ProductNotFoundException;
+import com.thedavestack.productcatalog.mapper.ProductMapper;
+import com.thedavestack.productcatalog.model.Product;
+import com.thedavestack.productcatalog.service.ProductService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+    private final ProductMapper productMapper;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ProductResponse createProduct(@RequestBody @Valid CreateProductRequest createProductRequest) {
+        Product product = productMapper.toEntity(createProductRequest);
+        Product createdProduct = productService.createProduct(product);
+        return productMapper.toResponse(createdProduct);
+    }
+
+    @GetMapping("/{id}")
+    public ProductResponse getProductById(@PathVariable String id) {
+        Product product = productService.findById(id).orElseThrow(() -> new ProductNotFoundException(id));
+        return productMapper.toResponse(product);
+    }
+}

--- a/spring/src/main/java/com/thedavestack/productcatalog/dto/CreateProductRequest.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/dto/CreateProductRequest.java
@@ -1,0 +1,10 @@
+package com.thedavestack.productcatalog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+public record CreateProductRequest(
+    @NotBlank(message = "Product name cannot be blank") String name,
+    String description,
+    @Positive(message = "Product price must be positive") BigDecimal price) {}

--- a/spring/src/main/java/com/thedavestack/productcatalog/dto/CreateProductRequest.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/dto/CreateProductRequest.java
@@ -1,10 +1,11 @@
 package com.thedavestack.productcatalog.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
 public record CreateProductRequest(
-    @NotBlank(message = "Product name cannot be blank") String name,
-    String description,
-    @Positive(message = "Product price must be positive") BigDecimal price) {}
+        @NotBlank(message = "Product name cannot be blank") String name,
+        String description,
+        @Positive(message = "Product price must be positive") BigDecimal price) {}

--- a/spring/src/main/java/com/thedavestack/productcatalog/dto/CreateProductRequest.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/dto/CreateProductRequest.java
@@ -1,3 +1,12 @@
+/**
+ * CreateProductRequest.java
+ *
+ * <p>Design Doc: ./docs/doc-1 - API-Design-Product-Catalog.md
+ *
+ * <p>Purpose: - Represents the DTO for creating a new product.
+ *
+ * <p>Last Updated: 2025-07-31 by Cline (Model: claude-3-opus, Task: task-10)
+ */
 package com.thedavestack.productcatalog.dto;
 
 import java.math.BigDecimal;

--- a/spring/src/main/java/com/thedavestack/productcatalog/dto/ProductResponse.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/dto/ProductResponse.java
@@ -1,3 +1,12 @@
+/**
+ * ProductResponse.java
+ *
+ * <p>Design Doc: ./docs/doc-1 - API-Design-Product-Catalog.md
+ *
+ * <p>Purpose: - Represents the DTO for a product response.
+ *
+ * <p>Last Updated: 2025-07-31 by Cline (Model: claude-3-opus, Task: task-10)
+ */
 package com.thedavestack.productcatalog.dto;
 
 import java.math.BigDecimal;

--- a/spring/src/main/java/com/thedavestack/productcatalog/dto/ProductResponse.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/dto/ProductResponse.java
@@ -1,0 +1,6 @@
+package com.thedavestack.productcatalog.dto;
+
+import java.math.BigDecimal;
+
+public record ProductResponse(
+        String id, String sku, String name, String description, BigDecimal price) {}

--- a/spring/src/main/java/com/thedavestack/productcatalog/exception/GlobalExceptionHandler.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.thedavestack.productcatalog.exception;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(ProductNotFoundException.class)
+    public ResponseEntity<Object> handleProductNotFoundException(
+            ProductNotFoundException ex, WebRequest request) {
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+}

--- a/spring/src/main/java/com/thedavestack/productcatalog/exception/GlobalExceptionHandler.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.thedavestack.productcatalog.exception;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;

--- a/spring/src/main/java/com/thedavestack/productcatalog/exception/GlobalExceptionHandler.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/exception/GlobalExceptionHandler.java
@@ -1,3 +1,12 @@
+/**
+ * GlobalExceptionHandler.java
+ *
+ * <p>Design Doc: ./docs/doc-1 - API-Design-Product-Catalog.md
+ *
+ * <p>Purpose: - Provides a centralized exception handling mechanism for the application.
+ *
+ * <p>Last Updated: 2025-07-31 by Cline (Model: claude-3-opus, Task: task-10)
+ */
 package com.thedavestack.productcatalog.exception;
 
 import java.time.LocalDateTime;

--- a/spring/src/main/java/com/thedavestack/productcatalog/mapper/ProductMapper.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/mapper/ProductMapper.java
@@ -1,9 +1,10 @@
 package com.thedavestack.productcatalog.mapper;
 
+import org.springframework.stereotype.Component;
+
 import com.thedavestack.productcatalog.dto.CreateProductRequest;
 import com.thedavestack.productcatalog.dto.ProductResponse;
 import com.thedavestack.productcatalog.model.Product;
-import org.springframework.stereotype.Component;
 
 @Component
 public class ProductMapper {

--- a/spring/src/main/java/com/thedavestack/productcatalog/mapper/ProductMapper.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/mapper/ProductMapper.java
@@ -1,0 +1,27 @@
+package com.thedavestack.productcatalog.mapper;
+
+import com.thedavestack.productcatalog.dto.CreateProductRequest;
+import com.thedavestack.productcatalog.dto.ProductResponse;
+import com.thedavestack.productcatalog.model.Product;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductMapper {
+
+    public Product toEntity(CreateProductRequest createProductRequest) {
+        Product product = new Product();
+        product.setName(createProductRequest.name());
+        product.setDescription(createProductRequest.description());
+        product.setPrice(createProductRequest.price());
+        return product;
+    }
+
+    public ProductResponse toResponse(Product product) {
+        return new ProductResponse(
+                product.getId(),
+                product.getSku(),
+                product.getName(),
+                product.getDescription(),
+                product.getPrice());
+    }
+}

--- a/spring/src/main/java/com/thedavestack/productcatalog/mapper/ProductMapper.java
+++ b/spring/src/main/java/com/thedavestack/productcatalog/mapper/ProductMapper.java
@@ -1,3 +1,12 @@
+/**
+ * ProductMapper.java
+ *
+ * <p>Design Doc: ./docs/doc-1 - API-Design-Product-Catalog.md
+ *
+ * <p>Purpose: - Maps between Product entities and DTOs.
+ *
+ * <p>Last Updated: 2025-07-31 by Cline (Model: claude-3-opus, Task: task-10)
+ */
 package com.thedavestack.productcatalog.mapper;
 
 import org.springframework.stereotype.Component;

--- a/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerIT.java
+++ b/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerIT.java
@@ -1,3 +1,12 @@
+/**
+ * ProductControllerIT.java
+ *
+ * <p>Design Doc: ./docs/doc-1 - API-Design-Product-Catalog.md
+ *
+ * <p>Purpose: - Provides integration tests for the ProductController.
+ *
+ * <p>Last Updated: 2025-07-31 by Cline (Model: claude-3-opus, Task: task-10)
+ */
 package com.thedavestack.productcatalog.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerIT.java
+++ b/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerIT.java
@@ -1,0 +1,55 @@
+package com.thedavestack.productcatalog.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thedavestack.productcatalog.dto.CreateProductRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Testcontainers
+@Transactional
+class ProductControllerIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17.5-alpine");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createProduct_shouldReturnCreatedProduct() throws Exception {
+        CreateProductRequest request = new CreateProductRequest("Test Product", "Description", new BigDecimal("10.00"));
+
+        mockMvc.perform(post("/api/v1/products")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Test Product"));
+    }
+}

--- a/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerIT.java
+++ b/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerIT.java
@@ -1,7 +1,11 @@
 package com.thedavestack.productcatalog.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thedavestack.productcatalog.dto.CreateProductRequest;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,12 +18,8 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.math.BigDecimal;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thedavestack.productcatalog.dto.CreateProductRequest;
 
 @SpringBootTest
 @Testcontainers
@@ -36,19 +36,19 @@ class ProductControllerIT {
         registry.add("spring.datasource.password", postgres::getPassword);
     }
 
-    @Autowired
-    private MockMvc mockMvc;
+    @Autowired private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    @Autowired private ObjectMapper objectMapper;
 
     @Test
     void createProduct_shouldReturnCreatedProduct() throws Exception {
-        CreateProductRequest request = new CreateProductRequest("Test Product", "Description", new BigDecimal("10.00"));
+        CreateProductRequest request =
+                new CreateProductRequest("Test Product", "Description", new BigDecimal("10.00"));
 
-        mockMvc.perform(post("/api/v1/products")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(
+                        post("/api/v1/products")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.name").value("Test Product"));
     }

--- a/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerTest.java
+++ b/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerTest.java
@@ -1,3 +1,12 @@
+/**
+ * ProductControllerTest.java
+ *
+ * <p>Design Doc: ./docs/doc-1 - API-Design-Product-Catalog.md
+ *
+ * <p>Purpose: - Provides unit tests for the ProductController.
+ *
+ * <p>Last Updated: 2025-07-31 by Cline (Model: claude-3-opus, Task: task-10)
+ */
 package com.thedavestack.productcatalog.controller;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerTest.java
+++ b/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerTest.java
@@ -1,0 +1,89 @@
+package com.thedavestack.productcatalog.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thedavestack.productcatalog.dto.CreateProductRequest;
+import com.thedavestack.productcatalog.dto.ProductResponse;
+import com.thedavestack.productcatalog.mapper.ProductMapper;
+import com.thedavestack.productcatalog.model.Product;
+import com.thedavestack.productcatalog.service.ProductService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProductController.class)
+class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProductService productService;
+
+    @MockitoBean
+    private ProductMapper productMapper;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createProduct_shouldReturnCreatedProduct() throws Exception {
+        CreateProductRequest request = new CreateProductRequest("Test Product", "Description", new BigDecimal("10.00"));
+        Product product = new Product();
+        product.setId("1");
+        product.setName("Test Product");
+        product.setDescription("Description");
+        product.setPrice(new BigDecimal("10.00"));
+
+        ProductResponse response = new ProductResponse("1", "sku", "Test Product", "Description", new BigDecimal("10.00"));
+
+        when(productMapper.toEntity(any(CreateProductRequest.class))).thenReturn(product);
+        when(productService.createProduct(any(Product.class))).thenReturn(product);
+        when(productMapper.toResponse(any(Product.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/v1/products")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.name").value("Test Product"));
+    }
+
+    @Test
+    void getProductById_shouldReturnProduct() throws Exception {
+        Product product = new Product();
+        product.setId("1");
+        product.setName("Test Product");
+
+        ProductResponse response = new ProductResponse("1", "sku", "Test Product", "Description", new BigDecimal("10.00"));
+
+        when(productService.findById("1")).thenReturn(Optional.of(product));
+        when(productMapper.toResponse(any(Product.class))).thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/products/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.name").value("Test Product"));
+    }
+
+    @Test
+    void getProductById_shouldReturnNotFound() throws Exception {
+        when(productService.findById("1")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/products/1"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerTest.java
+++ b/spring/src/test/java/com/thedavestack/productcatalog/controller/ProductControllerTest.java
@@ -1,22 +1,5 @@
 package com.thedavestack.productcatalog.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thedavestack.productcatalog.dto.CreateProductRequest;
-import com.thedavestack.productcatalog.dto.ProductResponse;
-import com.thedavestack.productcatalog.mapper.ProductMapper;
-import com.thedavestack.productcatalog.model.Product;
-import com.thedavestack.productcatalog.service.ProductService;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.math.BigDecimal;
-import java.util.Optional;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -24,39 +7,56 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thedavestack.productcatalog.dto.CreateProductRequest;
+import com.thedavestack.productcatalog.dto.ProductResponse;
+import com.thedavestack.productcatalog.mapper.ProductMapper;
+import com.thedavestack.productcatalog.model.Product;
+import com.thedavestack.productcatalog.service.ProductService;
+
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    @Autowired private MockMvc mockMvc;
 
-    @MockitoBean
-    private ProductService productService;
+    @MockitoBean private ProductService productService;
 
-    @MockitoBean
-    private ProductMapper productMapper;
+    @MockitoBean private ProductMapper productMapper;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    @Autowired private ObjectMapper objectMapper;
 
     @Test
     void createProduct_shouldReturnCreatedProduct() throws Exception {
-        CreateProductRequest request = new CreateProductRequest("Test Product", "Description", new BigDecimal("10.00"));
+        CreateProductRequest request =
+                new CreateProductRequest("Test Product", "Description", new BigDecimal("10.00"));
         Product product = new Product();
         product.setId("1");
         product.setName("Test Product");
         product.setDescription("Description");
         product.setPrice(new BigDecimal("10.00"));
 
-        ProductResponse response = new ProductResponse("1", "sku", "Test Product", "Description", new BigDecimal("10.00"));
+        ProductResponse response =
+                new ProductResponse(
+                        "1", "sku", "Test Product", "Description", new BigDecimal("10.00"));
 
         when(productMapper.toEntity(any(CreateProductRequest.class))).thenReturn(product);
         when(productService.createProduct(any(Product.class))).thenReturn(product);
         when(productMapper.toResponse(any(Product.class))).thenReturn(response);
 
-        mockMvc.perform(post("/api/v1/products")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(
+                        post("/api/v1/products")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value("1"))
                 .andExpect(jsonPath("$.name").value("Test Product"));
@@ -68,7 +68,9 @@ class ProductControllerTest {
         product.setId("1");
         product.setName("Test Product");
 
-        ProductResponse response = new ProductResponse("1", "sku", "Test Product", "Description", new BigDecimal("10.00"));
+        ProductResponse response =
+                new ProductResponse(
+                        "1", "sku", "Test Product", "Description", new BigDecimal("10.00"));
 
         when(productService.findById("1")).thenReturn(Optional.of(product));
         when(productMapper.toResponse(any(Product.class))).thenReturn(response);
@@ -83,7 +85,6 @@ class ProductControllerTest {
     void getProductById_shouldReturnNotFound() throws Exception {
         when(productService.findById("1")).thenReturn(Optional.empty());
 
-        mockMvc.perform(get("/api/v1/products/1"))
-                .andExpect(status().isNotFound());
+        mockMvc.perform(get("/api/v1/products/1")).andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
This PR implements the REST endpoints for the product catalog, as described in task-10.

Changes include:
- Creation of `ProductController` with `POST` and `GET` endpoints.
- Addition of `CreateProductRequest` and `ProductResponse` DTOs.
- Implementation of `ProductMapper` for entity-DTO conversion.
- Addition of `GlobalExceptionHandler` for `ProductNotFoundException`.
- Unit and integration tests for the controller.