### PR TITLE
feat: update Docker Compose to use pre-built images from GitHub Container Registry

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -18,6 +18,9 @@ MCP_SERVER_NAME=product-catalog-mcp-server-prod
 MCP_SERVER_VERSION=2.0.0-prod
 MCP_SSE_ENDPOINT=/sse
 
+# Docker Image Configuration
+IMAGE_TAG=latest
+
 # Production Environment Features
 SPRING_PROFILES_ACTIVE=prod,docker
 

--- a/.env.stage.example
+++ b/.env.stage.example
@@ -18,6 +18,9 @@ MCP_SERVER_NAME=product-catalog-mcp-server-stage
 MCP_SERVER_VERSION=2.0.0-stage
 MCP_SSE_ENDPOINT=/sse
 
+# Docker Image Configuration
+IMAGE_TAG=stage
+
 # Stage Environment Features
 SPRING_PROFILES_ACTIVE=stage,docker
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,17 +293,27 @@ This application is fully containerized with production-ready Docker configurati
 
 #### Container Configurations
 
-**Development** (`docker-compose.yml`):
+**Local Development** (`docker-compose.local.yml`):
+- Uses local builds: `build: { context: ., dockerfile: Dockerfile }`
 - Single-node setup with PostgreSQL
 - Development profile with extended logging
 - Port 8080 exposed for local development
-- Volume mounts for hot-reload (optional)
+- Full debugging capabilities and hot-reload support
+
+**Staging** (`docker-compose.stage.yml`):
+- Uses pre-built images: `ghcr.io/the-dave-stack/product-catalog:${IMAGE_TAG:-stage}`
+- Resource limits: 768M memory, 1.5 CPU cores
+- Environment-based configuration for staging validation
+- Automated deployment via develop branch CI/CD
+- Optional nginx reverse proxy with stage-specific configuration
 
 **Production** (`docker-compose.prod.yml`):
+- Uses pre-built images: `ghcr.io/the-dave-stack/product-catalog:${IMAGE_TAG:-latest}`
 - Multi-service architecture with network isolation
-- Resource limits and restart policies
-- Environment-based configuration
-- Optional nginx reverse proxy with rate limiting
+- Resource limits: 1G memory, 2 CPU cores
+- Environment-based configuration with security hardening
+- Automated deployment via main branch CI/CD
+- Optional nginx reverse proxy with SSL/TLS and enhanced security
 - Horizontal scaling support
 
 #### Security Features
@@ -326,13 +336,16 @@ This application is fully containerized with production-ready Docker configurati
 ### Deployment Commands
 
 ```bash
-# Development
-docker compose up -d
+# Local Development (with local build)
+docker compose -f docker-compose.local.yml up -d
 
-# Production
+# Staging (using pre-built images - automated via develop branch)
+docker compose -f docker-compose.stage.yml up -d
+
+# Production (using pre-built images - automated via main branch)
 docker compose -f docker-compose.prod.yml up -d
 
-# Scaling
+# Production with scaling
 docker compose -f docker-compose.prod.yml up -d --scale product-catalog=3
 
 # With Reverse Proxy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,9 +29,7 @@ services:
           cpus: '0.5'
 
   product-catalog:
-    build: 
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/the-dave-stack/product-catalog:${IMAGE_TAG:-latest}
     restart: unless-stopped
     ports:
       - "${APP_PORT:-8080}:8080"

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -29,9 +29,7 @@ services:
           cpus: '0.3'
 
   product-catalog:
-    build: 
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/the-dave-stack/product-catalog:${IMAGE_TAG:-stage}
     restart: unless-stopped
     ports:
       - "${APP_PORT:-8080}:8080"


### PR DESCRIPTION
- Update stage and prod Docker Compose files to use ghcr.io images
- Add IMAGE_TAG environment variable to .env examples
- Configure stage to use 'stage' tag by default
- Configure prod to use 'latest' tag by default
- Update CLAUDE.md documentation to reflect new image usage pattern
- Maintain local development with local builds for hot-reload support

This change ensures consistent deployments using images built by GitHub Actions
rather than local builds for staging and production environments.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
